### PR TITLE
Add Traefik https redirect to allow dev access from Chrome

### DIFF
--- a/provisioning/dev/start.yml
+++ b/provisioning/dev/start.yml
@@ -45,7 +45,14 @@
           CRON_ENABLED: "true"
         labels:
           traefik.enable: "true"
+          traefik.http.routers.ps2alerts_api_http.rule: "Host(`dev.api.ps2alerts.com`)"
+          traefik.http.routers.ps2alerts_api_http.entrypoints: "web"
+          traefik.http.routers.ps2alerts_api.middlewares: "redirect-to-https"
+          traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: "https"
+
           traefik.http.routers.ps2alerts_api.rule: "Host(`dev.api.ps2alerts.com`)"
+          traefik.http.routers.ps2alerts_api.entrypoints: "websecure"
+          traefik.http.routers.ps2alerts_api.tls: "true"
           traefik.http.routers.ps2alerts_api.service: "ps2alerts_api_service"
           traefik.http.services.ps2alerts_api_service.loadbalancer.server.port: "3000"
           traefik.http.services.ps2alerts_api_service.loadbalancer.server.scheme: "http"


### PR DESCRIPTION
I found that when trying to access http://dev.api.ps2alerts.com from Chrome, Traefik would return `404 page not found`. After a _bunch_ of experimentation, I narrowed the problem down to Chrome forcing requests to use HTTPS. After learning how Traefik works, the solution was to add a second router with an HTTPS redirect middleware to the original router, and to split the routers up between the web and websecure entrypoints. 

The original router now accepts traffic from websecure and directs it to the API container, and the new router redirects web traffic to websecure.

I had to do a similar fix for the main website container as well.