### PR TITLE
Add adjustedBattleRank to API

### DIFF
--- a/src/modules/data/entities/aggregate/common/character.embed.ts
+++ b/src/modules/data/entities/aggregate/common/character.embed.ts
@@ -41,7 +41,7 @@ export default class CharacterEmbed {
         type: 'number',
         default: 0,
     })
-    asp: number;
+    asp: number = 0;
 
     @ApiProperty({example: 210, description: 'Character Adjusted Battle Rank'})
     @Column({

--- a/src/modules/data/entities/aggregate/common/character.embed.ts
+++ b/src/modules/data/entities/aggregate/common/character.embed.ts
@@ -36,12 +36,18 @@ export default class CharacterEmbed {
     })
     battleRank: number;
 
-    @ApiProperty({example: true, description: 'Character is ASPed'})
+    @ApiProperty({example: 1, description: 'Character ASP Rank'})
     @Column({
-        type: 'boolean',
-        default: false,
+        type: 'number',
+        default: 0,
     })
-    asp: boolean;
+    asp: number;
+
+    @ApiProperty({example: 210, description: 'Character Adjusted Battle Rank'})
+    @Column({
+        type: 'number',
+    })
+    adjustedBattleRank: number;
 
     @ApiProperty({type: OutfitEmbed, description: 'Character outfit information'})
     @Column(() => OutfitEmbed)

--- a/src/modules/data/entities/aggregate/common/character.embed.ts
+++ b/src/modules/data/entities/aggregate/common/character.embed.ts
@@ -41,7 +41,7 @@ export default class CharacterEmbed {
         type: 'number',
         default: 0,
     })
-    asp: number = 0;
+    asp = 0;
 
     @ApiProperty({example: 210, description: 'Character Adjusted Battle Rank'})
     @Column({


### PR DESCRIPTION
This change adds the `adjustedBattleRank` to the character embed so that any endpoint that returns a character includes the new field. It also converts `asp` from boolean to number in the API. Also sets the default value of `asp` to 0 if it is otherwise not provided