### PR TITLE
ps2AlertsEventType integration

### DIFF
--- a/src/modules/data/entities/aggregate/global/global.character.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/global/global.character.aggregate.entity.ts
@@ -6,7 +6,7 @@ import {World, worldArray} from '../../../ps2alerts-constants/world';
 import CharacterEmbed from '../common/character.embed';
 import {Bracket, ps2alertsBracketArray} from '../../../ps2alerts-constants/bracket';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_global_characters',
@@ -91,12 +91,12 @@ export default class GlobalCharacterAggregateEntity {
     factionKills: FactionVersusFactionEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/global/global.facility.control.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/global/global.facility.control.aggregate.entity.ts
@@ -6,7 +6,7 @@ import {World, worldArray} from '../../../ps2alerts-constants/world';
 import FacilityFactionControl from '../common/facility.faction.control.embed';
 import {Bracket, ps2alertsBracketArray} from '../../../ps2alerts-constants/bracket';
 import FacilityEmbed from '../common/facility.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_global_facility_controls',
@@ -57,12 +57,12 @@ export default class GlobalFacilityControlAggregateEntity {
     totals: FacilityFactionControl;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/global/global.faction.combat.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/global/global.faction.combat.aggregate.entity.ts
@@ -6,7 +6,7 @@ import {World, worldArray} from '../../../ps2alerts-constants/world';
 import CombatStats from '../common/combat.stats.embed';
 import {Bracket, ps2alertsBracketArray} from '../../../ps2alerts-constants/bracket';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_global_faction_combats',
@@ -65,12 +65,12 @@ export default class GlobalFactionCombatAggregateEntity {
     factionKills: FactionVersusFactionEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/global/global.loadout.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/global/global.loadout.aggregate.entity.ts
@@ -6,7 +6,7 @@ import {Loadout, loadoutArray} from '../../../ps2alerts-constants/loadout';
 import {World, worldArray} from '../../../ps2alerts-constants/world';
 import {Bracket, ps2alertsBracketArray} from '../../../ps2alerts-constants/bracket';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_global_loadouts',
@@ -88,12 +88,12 @@ export default class GlobalLoadoutAggregateEntity {
     factionKills: FactionVersusFactionEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/global/global.outfit.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/global/global.outfit.aggregate.entity.ts
@@ -6,7 +6,7 @@ import {World, worldArray} from '../../../ps2alerts-constants/world';
 import OutfitEmbed from '../common/outfit.embed';
 import {Bracket, ps2alertsBracketArray} from '../../../ps2alerts-constants/bracket';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_global_outfits',
@@ -99,12 +99,12 @@ export default class GlobalOutfitAggregateEntity {
     factionKills: FactionVersusFactionEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/global/global.vehicle.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/global/global.vehicle.aggregate.entity.ts
@@ -6,7 +6,7 @@ import VehicleStatsEmbed from '../common/vehicle.vs.vehicle.embed';
 import {World, worldArray} from '../../../ps2alerts-constants/world';
 import {Vehicle, vehicleArray} from '../../../ps2alerts-constants/vehicle';
 import {Bracket, ps2alertsBracketArray} from '../../../ps2alerts-constants/bracket';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_global_vehicles',
@@ -87,12 +87,12 @@ export default class GlobalVehicleAggregateEntity {
     vehicleTeamkilledMatrix: object; // TODO: Fix this to be an object keyed via the Vehicle enum. Left it free for now.
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/global/global.vehicle.character.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/global/global.vehicle.character.aggregate.entity.ts
@@ -6,7 +6,7 @@ import VehicleStatsEmbed from '../common/vehicle.vs.vehicle.embed';
 import {World, worldArray} from '../../../ps2alerts-constants/world';
 import {Vehicle, vehicleArray} from '../../../ps2alerts-constants/vehicle';
 import {Bracket, ps2alertsBracketArray} from '../../../ps2alerts-constants/bracket';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_global_vehicles_characters',
@@ -94,12 +94,12 @@ export default class GlobalVehicleCharacterAggregateEntity {
     vehicleTeamkilledMatrix: object; // TODO: Fix this to be an object keyed via the Vehicle enum. Left it free for now.
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/global/global.victory.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/global/global.victory.aggregate.entity.ts
@@ -5,7 +5,7 @@ import {Exclude} from 'class-transformer';
 import {World, worldArray} from '../../../ps2alerts-constants/world';
 import {Zone, zoneArray} from '../../../ps2alerts-constants/zone';
 import {Bracket, ps2alertsBracketArray} from '../../../ps2alerts-constants/bracket';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_global_victories',
@@ -71,12 +71,12 @@ export default class GlobalVictoryAggregateEntity {
     draws: number;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/global/global.weapon.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/global/global.weapon.aggregate.entity.ts
@@ -6,7 +6,7 @@ import {World, worldArray} from '../../../ps2alerts-constants/world';
 import ItemEmbed from '../common/item.embed';
 import {Bracket, ps2alertsBracketArray} from '../../../ps2alerts-constants/bracket';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_global_weapons',
@@ -75,12 +75,12 @@ export default class GlobalWeaponAggregateEntity {
     factionKills: FactionVersusFactionEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/instance/instance.character.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/instance/instance.character.aggregate.entity.ts
@@ -5,7 +5,7 @@ import {Column, ObjectIdColumn, Entity, Index, ObjectID} from 'typeorm';
 import CharacterEmbed from '../common/character.embed';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
 import XperminuteEmbed from '../common/xperminute.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_instance_characters',
@@ -93,12 +93,12 @@ export default class InstanceCharacterAggregateEntity {
     xPerMinutes: XperminuteEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/instance/instance.combat.history.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/instance/instance.combat.history.aggregate.entity.ts
@@ -3,7 +3,7 @@ import {ApiProperty} from '@nestjs/swagger';
 import {Exclude} from 'class-transformer';
 import {Column, ObjectIdColumn, Entity, Index, ObjectID} from 'typeorm';
 import CombatStats from '../common/combat.stats.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_instance_combat_histories',
@@ -47,12 +47,12 @@ export default class InstanceCombatHistoryAggregateEntity {
     totals: CombatStats;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/instance/instance.facility.control.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/instance/instance.facility.control.aggregate.entity.ts
@@ -4,7 +4,7 @@ import {Exclude} from 'class-transformer';
 import {Column, ObjectIdColumn, Entity, Index, ObjectID} from 'typeorm';
 import FacilityFactionControl from '../common/facility.faction.control.embed';
 import FacilityEmbed from '../common/facility.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_instance_facility_controls',
@@ -46,12 +46,12 @@ export default class InstanceFacilityControlAggregateEntity {
     totals: FacilityFactionControl;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/instance/instance.faction.combat.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/instance/instance.faction.combat.aggregate.entity.ts
@@ -4,7 +4,7 @@ import {Exclude} from 'class-transformer';
 import {Column, ObjectIdColumn, Entity, ObjectID, Index} from 'typeorm';
 import CombatStats from '../common/combat.stats.embed';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_instance_faction_combats',
@@ -47,12 +47,12 @@ export default class InstanceFactionCombatAggregateEntity {
     factionKills: FactionVersusFactionEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/instance/instance.loadout.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/instance/instance.loadout.aggregate.entity.ts
@@ -4,7 +4,7 @@ import {Exclude} from 'class-transformer';
 import {Column, ObjectIdColumn, Entity, Index, ObjectID} from 'typeorm';
 import {Loadout, loadoutArray} from '../../../ps2alerts-constants/loadout';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_instance_loadouts',
@@ -77,12 +77,12 @@ export default class InstanceLoadoutAggregateEntity {
     factionKills: FactionVersusFactionEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/instance/instance.outfit.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/instance/instance.outfit.aggregate.entity.ts
@@ -5,7 +5,7 @@ import {Column, ObjectIdColumn, Entity, Index, ObjectID} from 'typeorm';
 import OutfitEmbed from '../common/outfit.embed';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
 import XperminuteOutfitEmbed from '../common/xperminute.outfit.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_instance_outfits',
@@ -107,12 +107,12 @@ export default class InstanceOutfitAggregateEntity {
     xPerMinutes: XperminuteOutfitEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/instance/instance.vehicle.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/instance/instance.vehicle.aggregate.entity.ts
@@ -4,7 +4,7 @@ import {Exclude} from 'class-transformer';
 import {Column, ObjectIdColumn, Entity, Index, ObjectID} from 'typeorm';
 import VehicleStatsEmbed from '../common/vehicle.vs.vehicle.embed';
 import {Vehicle} from '../../../ps2alerts-constants/vehicle';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_instance_vehicles',
@@ -78,12 +78,12 @@ export default class InstanceVehicleAggregateEntity {
     vehicleTeamkilledMatrix: object; // TODO: Fix this to be an object keyed via the Vehicle enum. Left it free for now.
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/instance/instance.vehicle.character.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/instance/instance.vehicle.character.aggregate.entity.ts
@@ -4,7 +4,7 @@ import {Exclude} from 'class-transformer';
 import {Column, ObjectIdColumn, Entity, Index, ObjectID} from 'typeorm';
 import VehicleStatsEmbed from '../common/vehicle.vs.vehicle.embed';
 import {Vehicle} from '../../../ps2alerts-constants/vehicle';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_instance_vehicles_characters',
@@ -84,12 +84,12 @@ export default class InstanceVehicleCharacterAggregateEntity {
     vehicleTeamkilledMatrix: object; // TODO: Fix this to be an object keyed via the Vehicle enum. Left it free for now.
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/aggregate/instance/instance.weapon.aggregate.entity.ts
+++ b/src/modules/data/entities/aggregate/instance/instance.weapon.aggregate.entity.ts
@@ -4,7 +4,7 @@ import {Exclude} from 'class-transformer';
 import {Column, ObjectIdColumn, Entity, Index, ObjectID} from 'typeorm';
 import ItemEmbed from '../common/item.embed';
 import FactionVersusFactionEmbed from '../common/faction.versus.faction.embed';
-import {Ps2alertsEventType} from '../../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'aggregate_instance_weapons',
@@ -60,12 +60,12 @@ export default class InstanceWeaponAggregateEntity {
     factionKills: FactionVersusFactionEmbed;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
         description: 'PS2Alerts Event Type for the aggregate',
     })
     @Column({
         type: 'number',
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2AlertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 }

--- a/src/modules/data/entities/instance/instance.metagame.territory.entity.ts
+++ b/src/modules/data/entities/instance/instance.metagame.territory.entity.ts
@@ -9,7 +9,7 @@ import {Exclude} from 'class-transformer';
 import MetagameTerritoryResultEmbed from '../aggregate/common/metagame.territory.result.embed';
 import {Bracket, ps2alertsBracketArray} from '../../ps2alerts-constants/bracket';
 import InstanceFeaturesEmbed from './instance.features.embed';
-import {Ps2alertsEventType, ps2alertsEventTypeArray} from '../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType, ps2AlertsEventTypeArray} from '../../ps2alerts-constants/ps2AlertsEventType';
 
 @Entity({
     name: 'instance_metagame_territories',
@@ -84,15 +84,15 @@ export default class InstanceMetagameTerritoryEntity {
     state: Ps2alertsEventState;
 
     @ApiProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
-        enum: ps2alertsEventTypeArray,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
+        enum: ps2AlertsEventTypeArray,
         description: 'The event type identifier - this is used to filter by live metagame and outfitwars etc',
     })
     @Column({
         type: 'number',
-        enum: ps2alertsEventTypeArray,
+        enum: ps2AlertsEventTypeArray,
     })
-    ps2alertsEventType: Ps2alertsEventType.LIVE_METAGAME;
+    ps2AlertsEventType: Ps2AlertsEventType.LIVE_METAGAME;
 
     @ApiProperty({example: Bracket.PRIME, enum: ps2alertsBracketArray, description: 'Activity bracket level of the instance'})
     @Column({

--- a/src/modules/data/entities/instance/instance.outfitwars.territory.entity.ts
+++ b/src/modules/data/entities/instance/instance.outfitwars.territory.entity.ts
@@ -7,9 +7,8 @@ import {ApiProperty} from '@nestjs/swagger';
 import {Exclude} from 'class-transformer';
 import InstanceFeaturesEmbed from './instance.features.embed';
 import OutfitWarsTerritoryResultEmbed from '../aggregate/common/outfitwars.territory.result.embed';
-import {Ps2alertsEventType, ps2alertsEventTypeArray} from '../../ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType, ps2AlertsEventTypeArray} from '../../ps2alerts-constants/ps2AlertsEventType';
 import OutfitwarsMetadataEmbed from './outfitwars.metadata.embed';
-
 
 @Entity({
     name: 'instance_outfitwars_2022',
@@ -110,15 +109,15 @@ export default class InstanceOutfitWarsTerritoryEntity {
     state: Ps2alertsEventState;
 
     @ApiProperty({
-        example: Ps2alertsEventType.OUTFIT_WARS_AUG_2022,
-        enum: ps2alertsEventTypeArray,
+        example: Ps2AlertsEventType.OUTFIT_WARS_AUG_2022,
+        enum: ps2AlertsEventTypeArray,
         description: 'The event type identifier - this is used to filter by live metagame and outfitwars etc',
     })
     @Column({
         type: 'number',
-        enum: ps2alertsEventTypeArray,
+        enum: ps2AlertsEventTypeArray,
     })
-    ps2alertsEventType: Ps2alertsEventType.OUTFIT_WARS_AUG_2022;
+    ps2AlertsEventType: Ps2AlertsEventType.OUTFIT_WARS_AUG_2022;
 
     @ApiProperty({description: 'Enabled features / data for this instance'})
     @Column(() => InstanceFeaturesEmbed)

--- a/src/modules/rest/Dto/CreateInstanceMetagameDto.ts
+++ b/src/modules/rest/Dto/CreateInstanceMetagameDto.ts
@@ -18,7 +18,7 @@ import {
 import {
     PS2AlertsInstanceFeaturesInterface,
 } from '../../data/ps2alerts-constants/interfaces/PS2AlertsInstanceFeaturesInterface';
-import {Ps2alertsEventType} from '../../data/ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../data/ps2alerts-constants/ps2AlertsEventType';
 
 export class CreateInstanceMetagameDto {
     @IsString()
@@ -89,10 +89,10 @@ export class CreateInstanceMetagameDto {
     @IsNumber()
     @IsOptional()
     @ApiModelProperty({
-        example: Ps2alertsEventType.LIVE_METAGAME,
-        default: Ps2alertsEventType.LIVE_METAGAME,
+        example: Ps2AlertsEventType.LIVE_METAGAME,
+        default: Ps2AlertsEventType.LIVE_METAGAME,
     })
-    ps2alertsEventType: Ps2alertsEventType;
+    ps2AlertsEventType: Ps2AlertsEventType;
 
     @IsNumber()
     @IsOptional()

--- a/src/modules/rest/Dto/outfitwars/CreateInstanceOutfitWarsDto.ts
+++ b/src/modules/rest/Dto/outfitwars/CreateInstanceOutfitWarsDto.ts
@@ -17,7 +17,7 @@ import {
 import {
     OutfitwarsTerritoryResultInterface,
 } from '../../../data/ps2alerts-constants/interfaces/OutfitwarsTerritoryResultInterface';
-import {Ps2alertsEventType} from '../../../data/ps2alerts-constants/ps2alertsEventType';
+import {Ps2AlertsEventType} from '../../../data/ps2alerts-constants/ps2AlertsEventType';
 import OutfitwarsMetadataEmbed from '../../../data/entities/instance/outfitwars.metadata.embed';
 
 export class CreateInstanceOutfitWarsDto {
@@ -80,9 +80,8 @@ export class CreateInstanceOutfitWarsDto {
     @IsNumber()
     @IsNotEmpty()
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    @ApiModelProperty({example: Ps2alertsEventType.OUTFIT_WARS_AUG_2022})
-    ps2alertsEventType: Ps2alertsEventType.OUTFIT_WARS_AUG_2022;
-
+    @ApiModelProperty({example: Ps2AlertsEventType.OUTFIT_WARS_AUG_2022})
+    ps2AlertsEventType: Ps2AlertsEventType.OUTFIT_WARS_AUG_2022;
 
     @IsObject()
     @IsNotEmpty()

--- a/src/modules/rest/controllers/aggregates/global/rest.aggregate.global.character.controller.ts
+++ b/src/modules/rest/controllers/aggregates/global/rest.aggregate.global.character.controller.ts
@@ -1,27 +1,35 @@
 import {Controller, Get, Inject, Param, Query} from '@nestjs/common';
 import {ApiOperation, ApiResponse, ApiTags} from '@nestjs/swagger';
-import GlobalCharacterAggregateEntity from '../../../../data/entities/aggregate/global/global.character.aggregate.entity';
+import GlobalCharacterAggregateEntity
+    from '../../../../data/entities/aggregate/global/global.character.aggregate.entity';
 import MongoOperationsService from '../../../../../services/mongo/mongo.operations.service';
 import {ApiImplicitQueries} from 'nestjs-swagger-api-implicit-queries-decorator';
-import {COMMON_IMPLICIT_QUERIES} from '../../common/rest.common.queries';
+import {AGGREGATE_COMMON_IMPLICIT_QUERIES} from '../../common/rest.common.queries';
 import {OptionalIntPipe} from '../../../pipes/OptionalIntPipe';
 import {World} from '../../../../data/ps2alerts-constants/world';
 import Pagination from '../../../../../services/mongo/pagination';
 import {Bracket} from '../../../../data/ps2alerts-constants/bracket';
 import {RedisCacheService} from '../../../../../services/cache/redis.cache.service';
-import {MandatoryIntPipe} from '../../../pipes/MandatoryIntPipe';
+import {Ps2AlertsEventType} from '../../../../data/ps2alerts-constants/ps2AlertsEventType';
+import {BRACKET_IMPLICIT_QUERY} from '../../common/rest.bracket.query';
+import {PS2ALERTS_EVENT_TYPE_QUERY} from '../../common/rest.ps2AlertsEventType.query';
+import {Ps2AlertsEventTypePipe} from '../../../pipes/Ps2AlertsEventTypePipe';
+import {BracketPipe} from '../../../pipes/BracketPipe';
+import {BaseAggregateController} from '../../BaseAggregateController';
 
 @ApiTags('Global Character Aggregates')
 @Controller('aggregates')
-export default class RestGlobalCharacterAggregateController {
+export default class RestGlobalCharacterAggregateController extends BaseAggregateController {
     constructor(
         @Inject(MongoOperationsService) private readonly mongoOperationsService: MongoOperationsService,
         private readonly cacheService: RedisCacheService,
-    ) {}
+    ) {
+        super();
+    }
 
     @Get('global/character')
     @ApiOperation({summary: 'Return a filtered list of GlobalCharacterAggregateEntity instances'})
-    @ApiImplicitQueries(COMMON_IMPLICIT_QUERIES)
+    @ApiImplicitQueries(AGGREGATE_COMMON_IMPLICIT_QUERIES)
     @ApiResponse({
         status: 200,
         description: 'The list of matching GlobalCharacterAggregateEntity aggregates',
@@ -29,26 +37,31 @@ export default class RestGlobalCharacterAggregateController {
         isArray: true,
     })
     async findAll(
-        @Query('world', OptionalIntPipe) world?: World,
+        @Query('bracket', BracketPipe) bracket: Bracket,
+            @Query('ps2AlertsEventType', Ps2AlertsEventTypePipe) ps2AlertsEventType: Ps2AlertsEventType,
+            @Query('world', OptionalIntPipe) world?: World,
             @Query('sortBy') sortBy?: string,
             @Query('order') order?: string,
             @Query('page', OptionalIntPipe) page?: number,
             @Query('pageSize', OptionalIntPipe) pageSize?: number,
-            @Query('bracket', MandatoryIntPipe) bracket?: Bracket,
+
     ): Promise<GlobalCharacterAggregateEntity[]> {
+        bracket = this.correctBracket(bracket, ps2AlertsEventType);
+
         const pagination = new Pagination({sortBy, order, page, pageSize}, true);
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        const key = `/global/character/W:${world}-B:${bracket}?P:${pagination.getKey()}`;
+        const key = `/global/character/W:${world}-B:${bracket}-ET:${ps2AlertsEventType}?P:${pagination.getKey()}`;
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return await this.cacheService.get(key) ?? await this.cacheService.set(
             key,
-            await this.mongoOperationsService.findMany(GlobalCharacterAggregateEntity, {world, bracket}, pagination),
+            await this.mongoOperationsService.findMany(GlobalCharacterAggregateEntity, {world, bracket, ps2AlertsEventType}, pagination),
             900);
     }
 
     @Get('global/character/:character')
     @ApiOperation({summary: 'Returns a single GlobalCharacterAggregateEntity aggregate'})
+    @ApiImplicitQueries([BRACKET_IMPLICIT_QUERY, PS2ALERTS_EVENT_TYPE_QUERY])
     @ApiResponse({
         status: 200,
         description: 'The GlobalCharacterAggregateEntity aggregate',
@@ -56,15 +69,18 @@ export default class RestGlobalCharacterAggregateController {
     })
     async findOne(
         @Param('character') character: string,
-            @Query('bracket', MandatoryIntPipe) bracket?: Bracket,
+            @Query('bracket', BracketPipe) bracket: Bracket,
+            @Query('ps2AlertsEventType', Ps2AlertsEventTypePipe) ps2AlertsEventType: Ps2AlertsEventType,
     ): Promise<GlobalCharacterAggregateEntity> {
+        bracket = this.correctBracket(bracket, ps2AlertsEventType);
+
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        const key = `/global/character/${character}/B:${bracket}`;
+        const key = `/global/character/${character}/B:${bracket}-ET:${ps2AlertsEventType}`;
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return await this.cacheService.get(key) ?? await this.cacheService.set(
             key,
-            await this.mongoOperationsService.findOne(GlobalCharacterAggregateEntity, {'character.id': character, bracket}),
+            await this.mongoOperationsService.findOne(GlobalCharacterAggregateEntity, {'character.id': character, bracket, ps2AlertsEventType}),
             300);
     }
 }


### PR DESCRIPTION
Adds `ps2AlertsEventType` to all aggregators in preparation for querying by the website by specific event type.

Event type is `1` aka `Ps2AlertsEventType.LIVE_METAGAME` by default unless specified by the request.