### PR TITLE
fix: type orm not found exceptions return 404

### DIFF
--- a/src/filters/type-orm.filter.ts
+++ b/src/filters/type-orm.filter.ts
@@ -1,0 +1,10 @@
+import {BaseExceptionFilter} from '@nestjs/core';
+import {Catch, NotFoundException} from '@nestjs/common';
+import {EntityNotFoundError} from 'typeorm';
+
+@Catch(EntityNotFoundError)
+export class TypeOrmFilter extends BaseExceptionFilter {
+    catch(): void {
+        throw new NotFoundException();
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {AppModule} from './app.module';
 import {DocumentBuilder, SwaggerModule} from '@nestjs/swagger';
 import compression from 'fastify-compress';
 import {ValidationPipe} from '@nestjs/common';
+import {TypeOrmFilter} from './filters/type-orm.filter';
 
 async function bootstrap(): Promise<void> {
     const app = await NestFactory.create<NestFastifyApplication>(
@@ -20,6 +21,8 @@ async function bootstrap(): Promise<void> {
     );
 
     const config = app.get(ConfigService);
+
+    app.useGlobalFilters(new TypeOrmFilter());
 
     app.enableCors(config.get('config'));
     void app.register(fastifyHelmet, {


### PR DESCRIPTION
TypeORM exceptions when an entity is not found result in a generic 500 response. I have added a filter so a 404 response is returned instead. This change does not affect the front-end as Axios will treat both 4xx and 5xx status codes the same, which is different then a normal 200 status code.