### PR TITLE
Disable outfitwars cronjob now that the season is over

### DIFF
--- a/src/modules/cron/CronModule.ts
+++ b/src/modules/cron/CronModule.ts
@@ -14,8 +14,8 @@ import {ConfigService} from '@nestjs/config';
 import * as redisStore from 'cache-manager-ioredis';
 import {RedisCacheService} from '../../services/cache/redis.cache.service';
 import {XpmCron} from './xpm.cron';
-import {OutfitWarsRankingsCron} from './outfitwars.rankings.cron';
-import OutfitwarsRankingEntity from '../data/entities/instance/outfitwars.ranking.entity';
+// import {OutfitWarsRankingsCron} from './outfitwars.rankings.cron';
+// import OutfitwarsRankingEntity from '../data/entities/instance/outfitwars.ranking.entity';
 
 @Module({
     imports: [
@@ -24,7 +24,7 @@ import OutfitwarsRankingEntity from '../data/entities/instance/outfitwars.rankin
             InstanceCombatHistoryAggregateEntity,
             InstanceFactionCombatAggregateEntity,
             InstanceMetagameTerritoryEntity,
-            OutfitwarsRankingEntity,
+            // OutfitwarsRankingEntity,
         ]),
         CacheModule.registerAsync({
             imports: [ConfigModule],
@@ -45,7 +45,7 @@ import OutfitwarsRankingEntity from '../data/entities/instance/outfitwars.rankin
         RedisCacheService,
         CombatHistoryCron,
         BracketCron,
-        OutfitWarsRankingsCron,
+        // OutfitWarsRankingsCron,
         XpmCron,
     ],
 })

--- a/src/modules/cron/outfitwars.rankings.cron.ts
+++ b/src/modules/cron/outfitwars.rankings.cron.ts
@@ -28,161 +28,159 @@ export class OutfitWarsRankingsCron {
 
     // @Cron('0 8 * 8,9,10 0') // 8AM UTC on every Sunday in August - October
     // @Cron('*/2 * * * *') // Swap to this to get the data now
+    /* eslint-disable @typescript-eslint/require-await */
     async handleCron(): Promise<void> {
         this.logger.log('Running Outfit Wars Matches job');
         this.logger.error('LithaFalcon outfit war ranking endpoint was removed 11/01/2022 - this job must be updated before running');
-        return;
 
-        /*
-        const serviceId: string | undefined = this.config.get('census.serviceId');
+        // const serviceId: string | undefined = this.config.get('census.serviceId');
 
-        if (!serviceId) {
-            throw new Error('Service ID is empty!');
-        }
+        // if (!serviceId) {
+        //     throw new Error('Service ID is empty!');
+        // }
 
-        const documents = [];
-        const conditionals = [];
+        // const documents = [];
+        // const conditionals = [];
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-        const outfitRankings: LithaFalconOutfitWarDataInterface[] = (await this.httpService.get(`${lithafalconCensusUrl}${lithafalconEndpoints.outfitWarRankings}`).toPromise()).data.outfit_war_list;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const matches: LithaFalconOutfitWarMatchResponseInterface = (await this.httpService.get(`${lithafalconCensusUrl}${lithafalconEndpoints.outfitWarMatches}`).toPromise()).data;
-        const timestamp = new Date();
+        // // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+        // const outfitRankings: LithaFalconOutfitWarDataInterface[] = (await this.httpService.get(`${lithafalconCensusUrl}${lithafalconEndpoints.outfitWarRankings}`).toPromise()).data.outfit_war_list;
+        // // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        // const matches: LithaFalconOutfitWarMatchResponseInterface = (await this.httpService.get(`${lithafalconCensusUrl}${lithafalconEndpoints.outfitWarMatches}`).toPromise()).data;
+        // const timestamp = new Date();
 
-        const outfitIdToMatchTime = new Map<string, Date>();
+        // const outfitIdToMatchTime = new Map<string, Date>();
 
-        for (const match of matches.outfit_war_match_list) {
-            // Date() expects a timestamp in ms, start_time is a timestamp in seconds
-            const matchTime = new Date(parseInt(match.start_time, 10) * 1000);
-            const outfitAOldMatch = outfitIdToMatchTime.get(match.outfit_a_id);
+        // for (const match of matches.outfit_war_match_list) {
+        //     // Date() expects a timestamp in ms, start_time is a timestamp in seconds
+        //     const matchTime = new Date(parseInt(match.start_time, 10) * 1000);
+        //     const outfitAOldMatch = outfitIdToMatchTime.get(match.outfit_a_id);
 
-            if (!outfitAOldMatch || outfitAOldMatch < matchTime) {
-                // Only overwrite the match time if its a future date
-                outfitIdToMatchTime.set(match.outfit_a_id, matchTime);
-            }
+        //     if (!outfitAOldMatch || outfitAOldMatch < matchTime) {
+        //         // Only overwrite the match time if its a future date
+        //         outfitIdToMatchTime.set(match.outfit_a_id, matchTime);
+        //     }
 
-            const outfitBOldMatch = outfitIdToMatchTime.get(match.outfit_b_id);
+        //     const outfitBOldMatch = outfitIdToMatchTime.get(match.outfit_b_id);
 
-            if (!outfitBOldMatch || outfitBOldMatch < matchTime) {
-                // Only overwrite the match time if its a future date
-                outfitIdToMatchTime.set(match.outfit_b_id, matchTime);
-            }
-        }
+        //     if (!outfitBOldMatch || outfitBOldMatch < matchTime) {
+        //         // Only overwrite the match time if its a future date
+        //         outfitIdToMatchTime.set(match.outfit_b_id, matchTime);
+        //     }
+        // }
 
-        for (const outfitRankingInterface of outfitRankings) {
-            const outfitWarRanking = this.parseLithaFalconRanking(outfitRankingInterface);
+        // for (const outfitRankingInterface of outfitRankings) {
+        //     const outfitWarRanking = this.parseLithaFalconRanking(outfitRankingInterface);
 
-            const outfit: OutfitEmbed | null = await this.mongoOperationsService.findOne<GlobalOutfitAggregateEntity>(
-                GlobalOutfitAggregateEntity, {
-                    'outfit.id': outfitWarRanking.outfit_id,
-                },
-            ).then((entity: GlobalOutfitAggregateEntity) => {
-                return entity.outfit;
-            }).catch(() => {
-                this.logger.warn('Failed to find outfit with our own data! Falling back to census!');
-                return this.httpService.get(`${getCensusBaseUrl(serviceId, CensusEnvironment.PC)}/outfit?outfit_id=${outfitWarRanking.outfit_id}&c:show=alias,name,leader_character_id,outfit_id&c:join=type:character^on:leader_character_id^to:character_id^show:faction_id^inject_at:leader&c:limit=1`).toPromise().then((res) => {
-                    const data = res.data as OutfitLeaderCharacterFactionJoinInterface;
+        //     const outfit: OutfitEmbed | null = await this.mongoOperationsService.findOne<GlobalOutfitAggregateEntity>(
+        //         GlobalOutfitAggregateEntity, {
+        //             'outfit.id': outfitWarRanking.outfit_id,
+        //         },
+        //     ).then((entity: GlobalOutfitAggregateEntity) => {
+        //         return entity.outfit;
+        //     }).catch(() => {
+        //         this.logger.warn('Failed to find outfit with our own data! Falling back to census!');
+        //         return this.httpService.get(`${getCensusBaseUrl(serviceId, CensusEnvironment.PC)}/outfit?outfit_id=${outfitWarRanking.outfit_id}&c:show=alias,name,leader_character_id,outfit_id&c:join=type:character^on:leader_character_id^to:character_id^show:faction_id^inject_at:leader&c:limit=1`).toPromise().then((res) => {
+        //             const data = res.data as OutfitLeaderCharacterFactionJoinInterface;
 
-                    if (data.error) {
-                        throw new Error(data.error);
-                    }
+        //             if (data.error) {
+        //                 throw new Error(data.error);
+        //             }
 
-                    const outfitInfo = data.outfit_list[0];
-                    return {
-                        id: outfitInfo.outfit_id,
-                        name: outfitInfo.name,
-                        faction: parseInt(outfitInfo.leader.faction_id, 10),
-                        world: outfitWarRanking.world_id,
-                        leader: outfitInfo.leader_character_id,
-                        tag: outfitInfo.alias,
-                    };
-                }).catch((err: Error) => {
-                    this.logger.error(`Census failed to return outfit '${outfitWarRanking.outfit_id}' with error '${err.message}'! Skipping it!`);
-                    return null;
-                });
-            });
+        //             const outfitInfo = data.outfit_list[0];
+        //             return {
+        //                 id: outfitInfo.outfit_id,
+        //                 name: outfitInfo.name,
+        //                 faction: parseInt(outfitInfo.leader.faction_id, 10),
+        //                 world: outfitWarRanking.world_id,
+        //                 leader: outfitInfo.leader_character_id,
+        //                 tag: outfitInfo.alias,
+        //             };
+        //         }).catch((err: Error) => {
+        //             this.logger.error(`Census failed to return outfit '${outfitWarRanking.outfit_id}' with error '${err.message}'! Skipping it!`);
+        //             return null;
+        //         });
+        //     });
 
-            if (outfit === null) {
-                continue;
-            }
+        //     if (outfit === null) {
+        //         continue;
+        //     }
 
-            const startTime = outfitIdToMatchTime.get(outfit.id);
+        //     const startTime = outfitIdToMatchTime.get(outfit.id);
 
-            if (!startTime) {
-                this.logger.error(`Missing start time for outfit ${outfit.id} on world ${outfitWarRanking.world_id}, not inserting!`);
-                continue;
-            }
+        //     if (!startTime) {
+        //         this.logger.error(`Missing start time for outfit ${outfit.id} on world ${outfitWarRanking.world_id}, not inserting!`);
+        //         continue;
+        //     }
 
-            if (Number.isNaN(outfitWarRanking.ranking_parameters.Wins)
-                || Number.isNaN(outfitWarRanking.ranking_parameters.Losses)
-                || Number.isNaN(outfitWarRanking.ranking_parameters.TiebreakerPoints)
-            ) {
-                this.logger.error(`Missing Wins or Losses or Tiebreaker points for outfit ${outfit.name} on world ${outfitWarRanking.world_id}, checking for existing!`);
-                const result = await this.mongoOperationsService.findOne(
-                    OutfitwarsRankingEntity, {
-                        round: outfitWarRanking.ranking_parameters.MatchesPlayed + 1,
-                        'outfit.id': outfit.id,
-                    }).catch(() => {
-                    this.logger.error(`Ranking for round ${outfitWarRanking.ranking_parameters.MatchesPlayed + 1} for outfit ${outfit.name} not found, adding malformed document.`);
-                });
+        //     if (Number.isNaN(outfitWarRanking.ranking_parameters.Wins)
+        //         || Number.isNaN(outfitWarRanking.ranking_parameters.Losses)
+        //         || Number.isNaN(outfitWarRanking.ranking_parameters.TiebreakerPoints)
+        //     ) {
+        //         this.logger.error(`Missing Wins or Losses or Tiebreaker points for outfit ${outfit.name} on world ${outfitWarRanking.world_id}, checking for existing!`);
+        //         const result = await this.mongoOperationsService.findOne(
+        //             OutfitwarsRankingEntity, {
+        //                 round: outfitWarRanking.ranking_parameters.MatchesPlayed + 1,
+        //                 'outfit.id': outfit.id,
+        //             }).catch(() => {
+        //             this.logger.error(`Ranking for round ${outfitWarRanking.ranking_parameters.MatchesPlayed + 1} for outfit ${outfit.name} not found, adding malformed document.`);
+        //         });
 
-                if (result) {
-                    // Do not update existing entity so we can fudge failed entries from Cobalt
-                    this.logger.error('Dropping malformed entry since we already have an entry for this outfit and round');
-                    continue;
-                }
-            }
+        //         if (result) {
+        //             // Do not update existing entity so we can fudge failed entries from Cobalt
+        //             this.logger.error('Dropping malformed entry since we already have an entry for this outfit and round');
+        //             continue;
+        //         }
+        //     }
 
-            let matchesPlayed = outfitWarRanking.ranking_parameters.MatchesPlayed;
+        //     let matchesPlayed = outfitWarRanking.ranking_parameters.MatchesPlayed;
 
-            if (outfitWarRanking.ranking_parameters.Wins + outfitWarRanking.ranking_parameters.Losses !== matchesPlayed) {
-                this.logger.warn('Matches played !== wins + losses');
-                matchesPlayed = outfitWarRanking.ranking_parameters.Wins + outfitWarRanking.ranking_parameters.Losses;
-            }
+        //     if (outfitWarRanking.ranking_parameters.Wins + outfitWarRanking.ranking_parameters.Losses !== matchesPlayed) {
+        //         this.logger.warn('Matches played !== wins + losses');
+        //         matchesPlayed = outfitWarRanking.ranking_parameters.Wins + outfitWarRanking.ranking_parameters.Losses;
+        //     }
 
-            const rankingParameters = Object.assign(outfitWarRanking.ranking_parameters, {MatchesPlayed: matchesPlayed});
+        //     const rankingParameters = Object.assign(outfitWarRanking.ranking_parameters, {MatchesPlayed: matchesPlayed});
 
-            documents.push({
-                $set: {
-                    rankingParameters,
-                    startTime,
-                },
-                $setOnInsert: {
-                    round: matchesPlayed + 1,
-                    world: outfitWarRanking.world_id,
-                    outfitWarId: outfitWarRanking.outfit_war_id,
-                    roundId: outfitWarRanking.round_id,
-                    outfit,
-                    order: outfitWarRanking.order,
-                    timestamp,
-                    instanceId: null,
-                },
-            });
+        //     documents.push({
+        //         $set: {
+        //             rankingParameters,
+        //             startTime,
+        //         },
+        //         $setOnInsert: {
+        //             round: matchesPlayed + 1,
+        //             world: outfitWarRanking.world_id,
+        //             outfitWarId: outfitWarRanking.outfit_war_id,
+        //             roundId: outfitWarRanking.round_id,
+        //             outfit,
+        //             order: outfitWarRanking.order,
+        //             timestamp,
+        //             instanceId: null,
+        //         },
+        //     });
 
-            conditionals.push({
-                round: outfitWarRanking.ranking_parameters.MatchesPlayed + 1,
-                'outfit.id': outfit.id,
-            });
-        }
+        //     conditionals.push({
+        //         round: outfitWarRanking.ranking_parameters.MatchesPlayed + 1,
+        //         'outfit.id': outfit.id,
+        //     });
+        // }
 
-        if (documents.length > 0) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-            await this.mongoOperationsService.upsertMany(
-                OutfitwarsRankingEntity,
-                documents,
-                conditionals,
-            ).catch((err: Error) => {
-                this.logger.error(`${err.name} during upsertMany: ${err.message}`);
-            });
-            this.logger.log('Outfit Wars rankings updated!');
-        }
+        // if (documents.length > 0) {
+        //     // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+        //     await this.mongoOperationsService.upsertMany(
+        //         OutfitwarsRankingEntity,
+        //         documents,
+        //         conditionals,
+        //     ).catch((err: Error) => {
+        //         this.logger.error(`${err.name} during upsertMany: ${err.message}`);
+        //     });
+        //     this.logger.log('Outfit Wars rankings updated!');
+        // }
 
-        // @See CronHealthIndicator
-        // This sets the fact that the cron has run, so if it hasn't been run it will be terminated.
-        const key = '/crons/outfitwarsrankings';
-        await this.cacheService.set(key, Date.now(), 60 * 65); // 1 hour 5 mins
-        this.logger.log('Set outfit wars ranking cron run time');
-        */
+        // // @See CronHealthIndicator
+        // // This sets the fact that the cron has run, so if it hasn't been run it will be terminated.
+        // const key = '/crons/outfitwarsrankings';
+        // await this.cacheService.set(key, Date.now(), 60 * 65); // 1 hour 5 mins
+        // this.logger.log('Set outfit wars ranking cron run time');
     }
 
     parseLithaFalconRanking(data: LithaFalconOutfitWarDataInterface): {

--- a/src/modules/cron/outfitwars.rankings.cron.ts
+++ b/src/modules/cron/outfitwars.rankings.cron.ts
@@ -1,20 +1,20 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {HttpService, Inject, Injectable, Logger} from '@nestjs/common';
-// import {Cron} from '@nestjs/schedule';
 import MongoOperationsService from '../../services/mongo/mongo.operations.service';
 import {RedisCacheService} from '../../services/cache/redis.cache.service';
-import {lithafalconCensusUrl, lithafalconEndpoints} from '../data/ps2alerts-constants/lithafalconEndpoints';
 import LithaFalconOutfitWarDataInterface from '../data/ps2alerts-constants/interfaces/LithaFalconOutfitWarDataInterface';
-import GlobalOutfitAggregateEntity from '../data/entities/aggregate/global/global.outfit.aggregate.entity';
-import OutfitwarsRankingEntity from '../data/entities/instance/outfitwars.ranking.entity';
-import OutfitEmbed from '../data/entities/aggregate/common/outfit.embed';
 import {ConfigService} from '@nestjs/config';
-import getCensusBaseUrl from '../data/ps2alerts-constants/utils/census';
-import {CensusEnvironment} from '../data/ps2alerts-constants/censusEnvironments';
-import {
-    OutfitLeaderCharacterFactionJoinInterface,
-} from '../data/ps2alerts-constants/interfaces/census-responses/OutfitLeaderCharacterFactionJoinInterface';
-import LithaFalconOutfitWarMatchResponseInterface from '../data/ps2alerts-constants/interfaces/LithaFalconOutfitWarMatchResponseInterface';
+// import {Cron} from '@nestjs/schedule';
+// import {lithafalconCensusUrl, lithafalconEndpoints} from '../data/ps2alerts-constants/lithafalconEndpoints';
+// import GlobalOutfitAggregateEntity from '../data/entities/aggregate/global/global.outfit.aggregate.entity';
+// import OutfitwarsRankingEntity from '../data/entities/instance/outfitwars.ranking.entity';
+// import OutfitEmbed from '../data/entities/aggregate/common/outfit.embed';
+// import getCensusBaseUrl from '../data/ps2alerts-constants/utils/census';
+// import {CensusEnvironment} from '../data/ps2alerts-constants/censusEnvironments';
+// import {
+//     OutfitLeaderCharacterFactionJoinInterface,
+// } from '../data/ps2alerts-constants/interfaces/census-responses/OutfitLeaderCharacterFactionJoinInterface';
+// import LithaFalconOutfitWarMatchResponseInterface from '../data/ps2alerts-constants/interfaces/LithaFalconOutfitWarMatchResponseInterface';
 
 @Injectable()
 export class OutfitWarsRankingsCron {
@@ -30,7 +30,10 @@ export class OutfitWarsRankingsCron {
     // @Cron('*/2 * * * *') // Swap to this to get the data now
     async handleCron(): Promise<void> {
         this.logger.log('Running Outfit Wars Matches job');
+        this.logger.error('LithaFalcon outfit war ranking endpoint was removed 11/01/2022 - this job must be updated before running');
+        return;
 
+        /*
         const serviceId: string | undefined = this.config.get('census.serviceId');
 
         if (!serviceId) {
@@ -179,6 +182,7 @@ export class OutfitWarsRankingsCron {
         const key = '/crons/outfitwarsrankings';
         await this.cacheService.set(key, Date.now(), 60 * 65); // 1 hour 5 mins
         this.logger.log('Set outfit wars ranking cron run time');
+        */
     }
 
     parseLithaFalconRanking(data: LithaFalconOutfitWarDataInterface): {

--- a/src/modules/cron/outfitwars.rankings.cron.ts
+++ b/src/modules/cron/outfitwars.rankings.cron.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {HttpService, Inject, Injectable, Logger} from '@nestjs/common';
-import {Cron} from '@nestjs/schedule';
+// import {Cron} from '@nestjs/schedule';
 import MongoOperationsService from '../../services/mongo/mongo.operations.service';
 import {RedisCacheService} from '../../services/cache/redis.cache.service';
 import {lithafalconCensusUrl, lithafalconEndpoints} from '../data/ps2alerts-constants/lithafalconEndpoints';
@@ -27,7 +27,7 @@ export class OutfitWarsRankingsCron {
     ) {}
 
     // @Cron('0 8 * 8,9,10 0') // 8AM UTC on every Sunday in August - October
-    @Cron('*/2 * * * *') // Swap to this to get the data now
+    // @Cron('*/2 * * * *') // Swap to this to get the data now
     async handleCron(): Promise<void> {
         this.logger.log('Running Outfit Wars Matches job');
 


### PR DESCRIPTION
This change disables the collection of outfit war ranking data from Falcon's API since the season is over, and Falcon is removing the endpoint we use and replacing it with a better API.

For next season we will need to update the cron job to use the correct endpoint before restarting it.