### PR TITLE
Add Lattice Versioning separate from Map Tile versioning

### DIFF
--- a/src/modules/data/entities/instance/instance.metagame.territory.entity.ts
+++ b/src/modules/data/entities/instance/instance.metagame.territory.entity.ts
@@ -109,9 +109,15 @@ export default class InstanceMetagameTerritoryEntity {
     @Column(() => InstanceFeaturesEmbed)
     features: InstanceFeaturesEmbed;
 
-    @ApiProperty({example: '1.0', description: 'The map\'s version, which enables us to provide different map layouts and tiles for historical alerts'})
+    @ApiProperty({example: '1.0', description: 'The map\'s version, which enables us to provide different map tiles for historical alerts'})
     @Column({
         type: 'string',
     })
     mapVersion: string;
+
+    @ApiProperty({example: '1.0', description: 'The lattice\'s version, which enables us to provide different lattice layouts for historical alerts'})
+    @Column({
+        type: 'string',
+    })
+    latticeVersion: string;
 }

--- a/src/modules/data/entities/instance/instance.outfitwars.territory.entity.ts
+++ b/src/modules/data/entities/instance/instance.outfitwars.territory.entity.ts
@@ -128,14 +128,17 @@ export default class InstanceOutfitWarsTerritoryEntity {
     @Column(() => InstanceFeaturesEmbed)
     features: InstanceFeaturesEmbed;
 
-    @ApiProperty({
-        example: '1.0',
-        description: 'The map\'s version, which enables us to provide different map layouts and tiles for historical alerts',
-    })
+    @ApiProperty({example: '1.0', description: 'The map\'s version, which enables us to provide different map tiles for historical alerts'})
     @Column({
         type: 'string',
     })
     mapVersion: string;
+
+    @ApiProperty({example: '1.0', description: 'The lattice\'s version, which enables us to provide different lattice layouts for historical alerts'})
+    @Column({
+        type: 'string',
+    })
+    latticeVersion: string;
 
     @ApiProperty({description: 'Outfit Wars team metadata'})
     @Column(() => OutfitwarsMetadataEmbed)

--- a/src/modules/rest/Dto/CreateInstanceMetagameDto.ts
+++ b/src/modules/rest/Dto/CreateInstanceMetagameDto.ts
@@ -110,4 +110,8 @@ export class CreateInstanceMetagameDto {
     @IsNotEmpty()
     @ApiModelProperty({example: '1.0'})
     mapVersion: string;
+
+    @IsNotEmpty()
+    @ApiModelProperty({example: '1.0'})
+    latticeVersion: string;
 }


### PR DESCRIPTION
These changes add `latticeVersion` to Territory Control instances created via the API, to allow for versioning of lattices separately from map tiles.