### PR TITLE
ci: Name the ESLint check, scope push triggers and pin token permissions

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -2,6 +2,10 @@
 name: 'Auto Assign PRs'
 on: pull_request
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   add-reviewers:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -5,6 +5,10 @@ on:
     # Runs 6am on Mondays (see https://crontab.guru)
     - cron: '0 6 * * 1'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   build-docker-images:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,10 @@ name: Build & Deploy Production
 on:
   push:
     branches: [master]
+
+permissions:
+  contents: read
+
 jobs:
   build-docker-images:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,6 +3,10 @@ name: Build & Deploy Staging
 on:
   push:
     branches: [staging]
+
+permissions:
+  contents: read
+
 jobs:
   build-docker-images:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -2,9 +2,15 @@
 name: ESLint
 on:
   push:
+    branches: [dev]
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   eslint:
+    name: ESLint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ts-compile.yml
+++ b/.github/workflows/ts-compile.yml
@@ -2,7 +2,12 @@
 name: Typescript Compile
 on:
   push:
+    branches: [dev]
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   typescript-compile:
     name: Typescript Compile


### PR DESCRIPTION
Part of standardising GitHub settings across the PS2Alerts, Satisfactory Factories, Diglet Bot and Albion Roads repos. This is the code half for this repo; the settings half is applied directly.

## What and why

**The ESLint check reports under the wrong name.** The `eslint` job has no `name:`, so its check context is `eslint`, whereas website and aggregator both report `ESLint`. Required status checks match on the literal string, so this only shows up at the moment you try to enforce it — which is exactly what is happening now. Named it explicitly.

**The push trigger has no branch filter.** Every push to any branch runs ESLint and Typescript Compile a second time, alongside the `pull_request` run. Scoped to `dev`, matching website and aggregator.

**Token permissions are now declared per workflow.** The repository default for `GITHUB_TOKEN` is `write`, which is more than anything here needs. Every workflow now states what it wants, so the default can drop to read-only:

| Workflow | Permissions | Why |
|---|---|---|
| ESLint, Typescript Compile | `contents: read` | checkout only |
| Build base image, Deploy Production, Deploy Staging | `contents: read` | authenticate to Docker Hub with their own secrets; need nothing from the GitHub token |
| Auto Assign PRs | `+ pull-requests: write` | assigns reviewers |

## Validation

All six workflow files parse as YAML. The ESLint and Typescript Compile runs on this PR are themselves the test of the rename and the trigger change — the checks on this PR should report as `ESLint` and `Typescript Compile`.

Once this merges, the repository default token permission drops to read-only and a branch ruleset requires both checks on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)